### PR TITLE
build.bash script and compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 *.pyc
 __pycache__/
 **.swp
+
+# Generated when using our build.bash script. Useful for when you want to use
+# something like code completion in vim and have it recognize all the ros
+# packages.
+compile_commands.json

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ sudo apt update
 sudo apt install python-pip
 ```
 
+## Building
+Run `build.bash` from any directory to build everything. This also generates
+a `compile_commands.json` file and symlinks it to this repo's root to allow for
+things like code completion in c++ files.
+
 ## Docker
 
 1. Setup the environment. (you only need to do this once)

--- a/build.bash
+++ b/build.bash
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+ORIGINAL_DIR=$(pwd)
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+source ~/ros/devel/setup.bash
+
+echo 'Changing directory to ros workspace.'
+cd ~/ros
+
+echo 'Building everything...'
+catkin_make -DCMAKE_EXPORT_COMPILE_COMMANDS=1
+
+echo "Returning to ${ORIGINAL_DIR}."
+cd "${ORIGINAL_DIR}"
+
+# Check if we've symlinked the compile_commands.json file yet. If we haven't,
+# then do it!
+if [ ! -e "${SCRIPT_DIR}/compile_commands.json" ]; then
+	echo "Symlinking compile_commands.json (for code completion coolness)."
+	ln -s ~/ros/build/compile_commands.json ${SCRIPT_DIR}/compile_commands.json
+fi


### PR DESCRIPTION
This adds a `build.bash` script for easier building from anywhere (no more changing directory multiple times, manually). Using this script also allows us to make cmake generate its `compile_commands.json` file, which we symlink into this repo's root for things like code completion in emacs and vim.